### PR TITLE
Add org-wide PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,54 @@
+### Desired Outcome
+
+*Please describe the desired outcome for this PR.  Said another way, what was
+the original request that resulted in these code changes?  Feel free to copy
+this information from the connected issue.*
+
+### Implemented Changes
+
+*Describe how the desired outcome above has been achieved with this PR. In
+particular, consider:*
+
+- _What's changed? Why were these changes made?_
+- _How should the reviewer approach this PR, especially if manual tests are required?_
+- _Are there relevant screenshots you can add to the PR description?_
+
+### Connected Issue/Story
+
+Resolves #[relevant GitHub issue(s), e.g. 76]
+
+CyberArk internal issue link: [insert issue ID]()
+
+### Definition of Done
+*At least 1 todo must be completed in the sections below for the PR to be
+merged.*
+
+#### Changelog
+
+- [ ] The CHANGELOG has been updated, or
+- [ ] This PR does not include user-facing changes and doesn't require a
+  CHANGELOG update
+
+#### Test coverage
+
+- [ ] This PR includes new unit and integration tests to go with the code
+  changes, or
+- [ ] The changes in this PR do not require tests
+
+#### Documentation
+
+- [ ] Docs (e.g. `README`s) were updated in this PR
+- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
+- [ ] This PR does not require updating any documentation
+
+#### Behavior
+
+- [ ] This PR changes product behavior and has been reviewed by a PO, or
+- [ ] These changes are part of a larger initiative that will be reviewed later, or
+- [ ] No behavior was changed with this PR
+
+#### Security
+
+- [ ] Security architect has reviewed the changes in this PR,
+- [ ] These changes are part of a larger initiative with a separate security review, or
+- [ ] There are no security aspects to these changes

--- a/ISSUE_TEMPLATE/bug.md
+++ b/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,50 @@
+---
+name: Bug
+about: Create a bug report to help this product
+title: ''
+labels: kind/bug
+assignees: ''
+
+---
+
+## Summary
+
+*Provide brief overview and context for the discovered bug.*
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+## Expected Results
+
+*A clear and concise description of what you expected to happen.*
+
+## Actual Results
+
+*A clear and concise description of what actually did happen. Include logs and
+screens shots, whenever possible*
+
+## Reproducible
+
+   * [ ] Always 
+   * [ ] Sometimes
+   * [ ] Non-Reproducible
+   
+## Version/Tag number
+
+*What version of the product are you running? Any version info that you can
+share is helpful.  For example, you might give the version from Docker logs,
+the Docker tag, a specific download URL, the output of the `/info` route, etc.*
+
+## Environment setup
+
+* Can you describe the environment in which this product is running? Is it running on a VM / in a container / in a cloud? 
+* Which cloud provider? Which container orchestrator (including version)? 
+* The more info you can share about your runtime environment, the better we may be able to reproduce the issue.
+
+## Additional Information
+
+*Add any other context about the problem here.*

--- a/ISSUE_TEMPLATE/epic.md
+++ b/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,29 @@
+---
+name: Epic
+about: Create an epic to plan a major new initiative
+title: ''
+labels: Epic, kind/epic
+assignees: ''
+
+---
+
+# _Name of the Epic_
+
+_Provide a short description of the epic here._
+
+## References
+- [_Aha Card Title_](https://cyberark.aha.io/features/)
+- [Feature Doc]()
+
+## Team
+- **Product Manager**: _Persons Name_ (@username)
+- **Product Owner**: _Persons Name_ (@username)
+- **Engineering Manager**: _Persons Name_ (@username)
+- **Feature Lead**: _Persons Name_ (@username)
+- **Engineers**:
+    - _Persons Name_ (@username)
+- **Technical Writer**: _Persons Name_ (@username)
+
+## Stories
+
+_List the stories here._

--- a/ISSUE_TEMPLATE/feature-request.md
+++ b/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: kind/enhancement
+assignees: ''
+
+---
+
+## Is your feature request related to a problem? Please describe.
+
+A clear and concise description of what the problem is. Ex. `I would like to see [...] because [...]`.
+Please include the intended use case and what the feature would improve on so that we can prioritize
+the feature accordingly.
+
+## Describe the solution you would like
+
+A clear and concise description of what the desired end result(s) would be.
+
+## Describe alternatives you have considered
+
+A clear and concise description of any alternative solutions or features that may be related to this that
+you have considered.
+
+## Additional context
+
+Add any other context information about the feature request here.

--- a/ISSUE_TEMPLATE/release.md
+++ b/ISSUE_TEMPLATE/release.md
@@ -1,0 +1,15 @@
+---
+name: Release
+about: Create a new release in this project
+title: 'Release version {version} of this project'
+labels: kind/release
+assignees: ''
+
+---
+
+Create a new release in this project following the contributing guide.
+
+Release version: {version}
+
+Issues / PRs that should be included in this release:
+- #{issue}

--- a/ISSUE_TEMPLATE/user-story.md
+++ b/ISSUE_TEMPLATE/user-story.md
@@ -1,0 +1,37 @@
+---
+name: User Story
+about: Propose an enhancement via a user story
+title: ''
+labels: kind/user-story
+assignees: ''
+
+---
+## User Story
+
+*Using the form below, relate the desired product behavior.  Feel free to
+additional, clarifying details below it if needed.  For more details on user
+stories, see this [article](https://www.atlassian.com/agile/project-management/user-stories).*
+
+**As a** <persona name>
+**I want** <desired behavior>
+**So that** <value of behavior> 
+
+### Test Scenarios
+
+*If desired, add one or more test scenarios required for user story acceptance.
+Ideally, they are executed by automated tests. For more details on Gerkin syntax,
+see this [article](https://cucumber.io/docs/gherkin/reference/)*
+
+**Given** <this setup/context>
+**When** <an action/event occurs>
+**Then** <the expected behavior/outcome>
+
+## Implementation
+
+### Notes
+
+### Implementation Tasks
+
+*The following issues have been created to implement this user story:*
+
+* <issue link>


### PR DESCRIPTION
This PR adds a default PR template for projects in the `conjurinc` org. The template is copied from the `cyberark` org PR template:
https://github.com/cyberark/.github/blob/main/.github/PULL_REQUEST_TEMPLATE.md